### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-ec, a plugin for [Fluentd](http://fluentd.org)2-metadata
+# fluent-plugin-ec2-metadata, a plugin for [Fluentd](http://fluentd.org)
 
 Fluentd plugin to add ec2 metadata fields to a event record
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
