### PR TITLE
Use aws-sdk-v1

### DIFF
--- a/fluent-plugin-ec2-metadata.gemspec
+++ b/fluent-plugin-ec2-metadata.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake"
   spec.add_runtime_dependency     "fluentd"
-  spec.add_runtime_dependency     "aws-sdk"
+  spec.add_runtime_dependency     "aws-sdk-v1"
 end

--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -5,7 +5,7 @@ module Fluent
     def initialize
       super
       require 'net/http'
-      require 'aws-sdk'
+      require 'aws-sdk-v1'
     end
 
     config_param :output_tag,  :string


### PR DESCRIPTION
This plugin uses the namespace of the `aws-sdk-v1`, but because requiring the `aws-sdk-v2`, an error will occur.

```
2015-04-22 11:31:38 +0900 [error]: unexpected error error="uninitialized constant Fluent::EC2MetadataOutput::AWS"
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-ec2-metadata-0.0.4/lib/fluent/plugin/out_ec2_metadata.rb:39:in `configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/agent.rb:127:in `add_match'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/agent.rb:60:in `block in configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/agent.rb:54:in `each'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/agent.rb:54:in `configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/root_agent.rb:82:in `configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/engine.rb:97:in `configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/engine.rb:77:in `run_configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:399:in `run_configure'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:138:in `block in start'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:266:in `call'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:266:in `main_process'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:241:in `block in supervise'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:240:in `fork'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:240:in `supervise'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/supervisor.rb:134:in `start'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/lib/fluent/command/fluentd.rb:167:in `<top (required)>'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.7/bin/fluentd:6:in `<top (required)>'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `load'
  2015-04-22 11:31:38 +0900 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
  2015-04-22 11:31:38 +0900 [error]: /usr/sbin/td-agent:7:in `load'
  2015-04-22 11:31:38 +0900 [error]: /usr/sbin/td-agent:7:in `<main>'
```

So, I modified to require the `aws-sdk-v1`.
