### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-ec2-metadata.gemspec
+++ b/fluent-plugin-ec2-metadata.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", ">= 3.1.0"
   spec.add_runtime_dependency     "fluentd"
   spec.add_runtime_dependency     "aws-sdk-v1"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible API.