### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -9,8 +9,8 @@ module Fluent
 
     config_param :output_tag,  :string
 
-    config_param :aws_key_id,  :string, :default => ENV['AWS_ACCESS_KEY_ID']
-    config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY']
+    config_param :aws_key_id,  :string, :default => ENV['AWS_ACCESS_KEY_ID'], :secret => true
+    config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY'], :secret => true
 
     def configure(conf)
       super


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature is concealing given parameters with xxxxxx when specified :secret => true in config_param.