### PR TITLE
Use output_tag only

### DIFF
--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -37,7 +37,7 @@ module Fluent
       @ec2_metadata['subnet_id']         = get_metadata("network/interfaces/macs/#{@ec2_metadata['mac']}/subnet-id")
 
       # get tags
-      if @map.values.any? { |v| v.match(/^\${tagset_/) }
+      if @map.values.any? { |v| v.match(/^\${tagset_/) } || @output_tag =~ /\${tagset_/
         require 'aws-sdk-v1'
 
         if @aws_key_id and @aws_sec_key then


### PR DESCRIPTION
I want to use this plugin to add EC2tag to output_tag 
But it doesn't seem to be fine...

```
<source>
  type forward
</source>

<match syslog.**>
  type ec2_metadata

  output_tag ${tagset_name}.${tag}
  <record>
  </record>
</match>

<match **>
  type stdout
</match>
```

```
$echo '{"json":"message hello ec2"}' | /opt/td-agent/embedded/bin/fluent-cat syslog.hoge

2015-08-13 20:33:07 +0000 [trace]: plugin/in_forward.rb:194:initialize: accepted fluent socket from '127.0.0.1:59785': object_id=30927020
2015-08-13 20:33:07 +0000 [warn]: plugin/out_ec2_metadata.rb:114:block in expand: ec2-metadata: unknown placeholder `${tagset_name}` found in a tag `syslog.hoge`
2015-08-13 20:33:07 +0000 .syslog.hoge: {"json":"message hello ec2"}
2015-08-13 20:33:07 +0000 [trace]: plugin/in_forward.rb:262:on_close: closed socket
[root@ip-172-31-21-67 td-agent]# 2015-08-13 20:33:07 +0000 fluent.trace: {"message":"accepted fluent socket from '127.0.0.1:59785': object_id=30927020"}
2015-08-13 20:33:07 +0000 fluent.warn: {"message":"ec2-metadata: unknown placeholder `${tagset_name}` found in a tag `syslog.hoge`"}
2015-08-13 20:33:07 +0000 fluent.trace: {"message":"closed socket"}
```

I have already changed it and confirm that it works for me.

```
$echo '{"json":"message hello ec2"}' | /opt/td-agent/embedded/bin/fluent-cat syslog.hoge

2015-08-13 21:20:50 +0000 [trace]: plugin/in_forward.rb:194:initialize: accepted fluent socket from '127.0.0.1:59807': object_id=23428280
2015-08-13 21:20:50 +0000 fluent-metadata.syslog.hoge: {"json":"message hello ec2"}
2015-08-13 21:20:50 +0000 [trace]: plugin/in_forward.rb:262:on_close: closed socket
[root@ip-172-31-21-67 td-agent]# 2015-08-13 21:20:50 +0000 fluent.trace: {"message":"accepted fluent socket from '127.0.0.1:59807': object_id=23428280"}
2015-08-13 21:20:50 +0000 fluent.trace: {"message":"closed socket"}
```

Could you check my pull request?

Thanks!