### PR TITLE
Add private ip to the list of collected metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Example:
         instance_id   ${instance_id}
         instance_type ${instance_type}
         az            ${availability_zone}
+        private_ip    ${private_ip}
         vpc_id        ${vpc_id}
         ami_id        ${image_id}
         account_id    ${account_id}
@@ -50,6 +51,7 @@ i-28b5ee77.foo.bar {
   "instance_id"   : "i-28b5ee77",
   "instance_type" : "m1.large",
   "az"            : "us-west-1b",
+  "private_ip     : "10.21.34.200",
   "vpc_id"        : "vpc-25dab194",
   "account_id"    : "123456789",
   "image_id"      : "ami-123456",
@@ -69,6 +71,7 @@ Or you can use filter version:
         hostname      ${tagset_name}
         instance_id   ${instance_id}
         instance_type ${instance_type}
+        private_ip    ${private_ip}
         az            ${availability_zone}
         vpc_id        ${vpc_id}
         ami_id        ${image_id}
@@ -86,6 +89,7 @@ The following placeholders are always available:
 * ${instance_type} instance type
 * ${availability_zone} availability zone
 * ${region} region
+* ${private_ip} private ip
 * ${mac} MAC address
 * ${vpc_id} vpc id
 * ${subnet_id} subnet id

--- a/lib/fluent/plugin/ec2_metadata.rb
+++ b/lib/fluent/plugin/ec2_metadata.rb
@@ -40,6 +40,7 @@ module Fluent
       @ec2_metadata['instance_type'] = get_metadata('instance-type')
       @ec2_metadata['availability_zone'] = get_metadata('placement/availability-zone')
       @ec2_metadata['region'] = @ec2_metadata['availability_zone'].chop
+      @ec2_metadata['private_ip'] = get_metadata('local-ipv4')
       @ec2_metadata['mac'] = get_metadata('mac')
       begin
         @ec2_metadata['vpc_id'] = get_metadata("network/interfaces/macs/#{@ec2_metadata['mac']}/vpc-id")

--- a/test/cassettes/ec2-classic.yml
+++ b/test/cassettes/ec2-classic.yml
@@ -119,6 +119,45 @@ http_interactions:
   recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
 - request:
     method: get
+    uri: http://169.254.169.254/latest/meta-data/local-ipv4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1870317889"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: 10.21.34.200
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
     uri: http://169.254.169.254/latest/meta-data/mac
     body:
       encoding: US-ASCII

--- a/test/cassettes/ec2-vpc.yml
+++ b/test/cassettes/ec2-vpc.yml
@@ -119,6 +119,45 @@ http_interactions:
   recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
 - request:
     method: get
+    uri: http://169.254.169.254/latest/meta-data/local-ipv4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1870317889"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: 10.21.34.200
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
     uri: http://169.254.169.254/latest/meta-data/mac
     body:
       encoding: US-ASCII

--- a/test/plugin/test_out_ec2_metadata.rb
+++ b/test/plugin/test_out_ec2_metadata.rb
@@ -43,6 +43,7 @@ class EC2MetadataOutputTest < Test::Unit::TestCase
 
       assert_equal("ami-123456", d.instance.ec2_metadata['image_id'])
       assert_equal("123456789", d.instance.ec2_metadata['account_id'])
+      assert_equal("10.21.34.200", d.instance.ec2_metadata['private_ip'])
 
       assert_equal("i-0c0c0000", d.instance.ec2_metadata['instance_id'])
       assert_equal("m3.large", d.instance.ec2_metadata['instance_type'])


### PR DESCRIPTION
The private ip is coming from the metadata local-ipv4. 
I used private_ip name because for most of the people this is more understandable then using local-ipv4