### PR TITLE
Pin at the fluentd-0.12.x branch, to avoid requiring ruby >= 2.0

### DIFF
--- a/fluent-plugin-ec2-metadata.gemspec
+++ b/fluent-plugin-ec2-metadata.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "test-unit", ">= 3.1.0"
-  spec.add_runtime_dependency     "fluentd"
+  spec.add_runtime_dependency     "fluentd", ">= 0.12", "< 0.13"
   spec.add_runtime_dependency     "oj"
   spec.add_runtime_dependency     "aws-sdk"
 end


### PR DESCRIPTION
The latest fluentd-0.14 gems require strptime, which in turns requires ruby >= 2.0

This is a major headache on ubuntu, where fluentd requires ruby 1.9.x