### PR TITLE
Adding colon and dash to capturing group

### DIFF
--- a/lib/fluent/plugin/ec2_metadata.rb
+++ b/lib/fluent/plugin/ec2_metadata.rb
@@ -24,10 +24,10 @@ module Fluent
 
       # get metadata first and then setup a refresh thread
       @ec2_metadata = Hash.new
-      set_metadata 
+      set_metadata
       set_tag
       @refresh_thread = Thread.new {
-        while true 
+        while true
           sleep @metadata_refresh_seconds
           set_metadata
           set_tag
@@ -144,7 +144,7 @@ module Fluent
       end
 
       def expand(str)
-        str.gsub(/(\${[a-z_]+(\[-?[0-9]+\])?}|__[A-Z_]+__)/) {
+        str.gsub(/(\${[a-z_:\-]+(\[-?[0-9]+\])?}|__[A-Z_]+__)/) {
           $log.warn "ec2-metadata: unknown placeholder `#{$1}` found in a tag `#{@placeholders['${tag}']}`" unless @placeholders.include?($1)
           @placeholders[$1]
         }


### PR DESCRIPTION
I also ran into issue [#22](https://github.com/takus/fluent-plugin-ec2-metadata/issues/22) when trying to use the following tag sets:
- aws:cloudformation:stack-name
- aws:cloudformation:stack-id

Before this change, with the following configuration, the field for INSTANCE_STACK_NAME would be the literal string `${tagset_aws:cloudformation:stack-name}` in the log record:
```
  <filter journald.**>
    @type ec2_metadata
    @id add_ec2_metadata
    metadata_refresh_seconds "#{ENV['FLUENTD_EC2_METADATA_REFRESH']}"
    <record>
      INSTANCE_ID         ${instance_id}
      INSTANCE_TYPE       ${instance_type}
      INSTANCE_NAME       ${tagset_name}
      INSTANCE_AZ         ${availability_zone}
      INSTANCE_AMI_ID     ${image_id}
      INSTANCE_ROLE       ${tagset_role}
      INSTANCE_PRODUCT    ${tagset_product}
      INSTANCE_STACK_NAME ${tagset_aws:cloudformation:stack-name}
    </record>
  </filter>
```
This was because the original gsub in PlaceholderExpander wouldn't match on the `:` or `-` used in the string for the tagset.

Thanks for considering this PR, and for creating this incredibly useful plugin in the first place!