### PR TITLE
Update test helper and travis for CodeClimate 1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ matrix:
     - rvm: 2.0.*
       gemfile: Gemfile
 before_install: gem update bundler
+after_script: codeclimate-test-reporter

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
The Code Climate test reporter gem v1.0 has breaking changes.  The changes
cause TravisCI to error out when running on PRs.  See
https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md

This commit updates the use of `codeclimate-test-reporter` as advised in the
above README.