### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 rvm:
-  - 2.0.*
   - 2.1.*
   - 2.2.*
   - 2.3.0
 gemfile:
   - Gemfile
-  - Gemfile.fluentd.0.12
-  - Gemfile.fluentd.0.10
-matrix:
-  exclude:
-    - rvm: 2.0.*
-      gemfile: Gemfile
 before_install: gem update bundler
 after_script: codeclimate-test-reporter

--- a/Gemfile.fluentd.0.10
+++ b/Gemfile.fluentd.0.10
@@ -1,9 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'fluentd', '~> 0.10.43'
-
-gemspec
-
-group :test do
-  gem 'codeclimate-test-reporter', require: nil
-end

--- a/Gemfile.fluentd.0.12
+++ b/Gemfile.fluentd.0.12
@@ -1,9 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'fluentd', '~> 0.12.0'
-
-gemspec
-
-group :test do
-  gem 'codeclimate-test-reporter', require: nil
-end

--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,4 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-task :default => :test
+task default: :test

--- a/lib/fluent/plugin/filter_ec2_metadata.rb
+++ b/lib/fluent/plugin/filter_ec2_metadata.rb
@@ -7,9 +7,9 @@ module Fluent::Plugin
 
     Fluent::Plugin.register_filter('ec2_metadata', self)
 
-    config_param :aws_key_id, :string, :default => ENV['AWS_ACCESS_KEY_ID'], :secret => true
-    config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY'], :secret => true
-    config_param :metadata_refresh_seconds, :integer, :default => 300
+    config_param :aws_key_id, :string, default: ENV['AWS_ACCESS_KEY_ID'], secret: true
+    config_param :aws_sec_key, :string, default: ENV['AWS_SECRET_ACCESS_KEY'], secret: true
+    config_param :metadata_refresh_seconds, :integer, default: 300
 
     attr_reader :ec2_metadata
 

--- a/lib/fluent/plugin/filter_ec2_metadata.rb
+++ b/lib/fluent/plugin/filter_ec2_metadata.rb
@@ -1,6 +1,7 @@
+require 'fluent/plugin/filter'
 require_relative 'ec2_metadata'
 
-module Fluent
+module Fluent::Plugin
   class EC2MetadataFilter < Filter
     include Fluent::EC2Metadata
 

--- a/lib/fluent/plugin/filter_ec2_metadata.rb
+++ b/lib/fluent/plugin/filter_ec2_metadata.rb
@@ -7,11 +7,6 @@ module Fluent::Plugin
 
     Fluent::Plugin.register_filter('ec2_metadata', self)
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     config_param :aws_key_id, :string, :default => ENV['AWS_ACCESS_KEY_ID'], :secret => true
     config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY'], :secret => true
     config_param :metadata_refresh_seconds, :integer, :default => 300

--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -10,9 +10,9 @@ module Fluent::Plugin
     helpers :event_emitter
 
     config_param :output_tag, :string
-    config_param :aws_key_id, :string, :default => ENV['AWS_ACCESS_KEY_ID'], :secret => true
-    config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY'], :secret => true
-    config_param :metadata_refresh_seconds, :integer, :default => 300
+    config_param :aws_key_id, :string, default: ENV['AWS_ACCESS_KEY_ID'], secret: true
+    config_param :aws_sec_key, :string, default: ENV['AWS_SECRET_ACCESS_KEY'], secret: true
+    config_param :metadata_refresh_seconds, :integer, default: 300
 
     attr_reader :ec2_metadata
 

--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -9,15 +9,6 @@ module Fluent::Plugin
 
     helpers :event_emitter
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
     config_param :output_tag, :string
     config_param :aws_key_id, :string, :default => ENV['AWS_ACCESS_KEY_ID'], :secret => true
     config_param :aws_sec_key, :string, :default => ENV['AWS_SECRET_ACCESS_KEY'], :secret => true


### PR DESCRIPTION
Hi, I've tried to migrate using v0.14 API.
Could you consider to start using v0.14 API in this plugin?

Please refer to [the upgrading v0.12 to v0.14 guide](http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12) in more details.

**Notice:** This PR contains breaking changes.