### PR TITLE
Add requirements section take2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 [Fluentd](http://fluentd.org) plugin to add ec2 metadata fields to a event record
 
+## Requirements
+
+| fluent-plugin-ec2-metadata | fluentd    | ruby   |
+|--------------------|------------|--------|
+|  >= 0.1.0            | v0.14.x | >= 2.1 |
+|  0.0.15 <=            | v0.12.x | >= 1.9 |
+
 ## Installation
 Use RubyGems:
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@
 
 [Fluentd](http://fluentd.org) plugin to add ec2 metadata fields to a event record
 
-## Requirements
-
-| fluent-plugin-ec2-metadata | fluentd    | ruby   |
-|--------------------|------------|--------|
-|  >= 0.0.16            | v0.14.x | >= 2.1 |
-|  0.0.15 <=            | v0.12.x | >= 1.9 |
-
 ## Installation
 Use RubyGems:
 


### PR DESCRIPTION
We should announce required Ruby and Fluentd versions in README.
This PR follows up #34.
Because fluent-plugin-ec2-metadata 0.0.16 had been yanked and released 0.1.0.