### PR TITLE
Use aws-sdk v3 service specific gem

### DIFF
--- a/fluent-plugin-ec2-metadata.gemspec
+++ b/fluent-plugin-ec2-metadata.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-ec2-metadata"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.authors       = ["SAKAMOTO Takumi"]
   spec.email         = ["takumi.saka@gmail.com"]
   spec.description   = %q{Fluentd output plugin to add ec2 metadata fields to a event record}

--- a/fluent-plugin-ec2-metadata.gemspec
+++ b/fluent-plugin-ec2-metadata.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "fluentd", "> 0.14.0"
   spec.add_runtime_dependency     "oj"
-  spec.add_runtime_dependency     "aws-sdk"
+  spec.add_runtime_dependency     "aws-sdk-ec2", "~> 1.1.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "vcr"

--- a/lib/fluent/plugin/ec2_metadata.rb
+++ b/lib/fluent/plugin/ec2_metadata.rb
@@ -4,7 +4,7 @@ module Fluent
     def initialize
       super
       require 'net/http'
-      require 'aws-sdk'
+      require 'aws-sdk-ec2'
       require 'oj'
     end
 


### PR DESCRIPTION
aws-sdk-v3 and service specific gems are released.

For EC2:
https://rubygems.org/gems/aws-sdk-ec2

Then, we can migrate to use aws-sdk v3 ec2 specific gem.

ref: https://aws.amazon.com/jp/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/