### PR TITLE
migrate to IMDSv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Example:
       aws_sec_key YOUR_AWS_SECRET/KEY
 
       metadata_refresh_seconds 300 # Optional, default 300 seconds
+      imdsv2 true                  # Optional, default false
 
       output_tag ${instance_id}.${tag}
       <record>
@@ -76,6 +77,7 @@ Or you can use filter version:
       aws_sec_key YOUR_AWS_SECRET/KEY
 
       metadata_refresh_seconds 300 # Optional, default 300 seconds
+      imdsv2 true                  # Optional, default false
 
       <record>
         hostname      ${tagset_name}

--- a/lib/fluent/plugin/filter_ec2_metadata.rb
+++ b/lib/fluent/plugin/filter_ec2_metadata.rb
@@ -10,6 +10,7 @@ module Fluent::Plugin
     config_param :aws_key_id, :string, default: ENV['AWS_ACCESS_KEY_ID'], secret: true
     config_param :aws_sec_key, :string, default: ENV['AWS_SECRET_ACCESS_KEY'], secret: true
     config_param :metadata_refresh_seconds, :integer, default: 300
+    config_param :imdsv2, :bool, default: false
 
     attr_reader :ec2_metadata
 

--- a/lib/fluent/plugin/out_ec2_metadata.rb
+++ b/lib/fluent/plugin/out_ec2_metadata.rb
@@ -13,6 +13,7 @@ module Fluent::Plugin
     config_param :aws_key_id, :string, default: ENV['AWS_ACCESS_KEY_ID'], secret: true
     config_param :aws_sec_key, :string, default: ENV['AWS_SECRET_ACCESS_KEY'], secret: true
     config_param :metadata_refresh_seconds, :integer, default: 300
+    config_param :imdsv2, :bool, default: false
 
     attr_reader :ec2_metadata
 

--- a/test/cassettes/ec2-vpc-with-imdsv2.yml
+++ b/test/cassettes/ec2-vpc-with-imdsv2.yml
@@ -1,0 +1,545 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://169.254.169.254/latest/api/token
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Aws-Ec2-Metadata-Token-Ttl-Seconds:
+      - '300'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '56'
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 12 Dec 2019 11:38:19 GMT
+      X-Aws-Ec2-Metadata-Token-Ttl-Seconds:
+      - '300'
+      Connection:
+      - close
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+    http_version:
+  recorded_at: Thu, 12 Dec 2019 11:38:19 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/instance-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1971254081"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '10'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: i-0c0c0000
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/instance-type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"765393446"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '8'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: m3.large
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/placement/availability-zone
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1870317889"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: ap-northeast-1b
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/local-ipv4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1870317889"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: 10.21.34.200
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/mac
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1996419393"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '17'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: 00:A0:00:0A:AA:00
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/network/interfaces/macs/00:A0:00:0A:AA:00/vpc-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1822409025"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '12'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: vpc-00000000
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/network/interfaces/macs/00:A0:00:0A:AA:00/subnet-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"1870330753"'
+      Last-Modified:
+      - Thu, 02 Jul 2015 12:49:17 GMT
+      Content-Length:
+      - '15'
+      Connection:
+      - close
+      Date:
+      - Sun, 13 Dec 2015 06:37:00 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: subnet-00000000
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 06:37:00 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/network/interfaces/macs/00:00:0A:AA:0A:0A/vpc-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '345'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Dec 2015 17:11:22 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="iso-8859-1"?>
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+         <head>
+          <title>404 - Not Found</title>
+         </head>
+         <body>
+          <h1>404 - Not Found</h1>
+         </body>
+        </html>
+    http_version:
+  recorded_at: Wed, 16 Dec 2015 17:11:22 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/meta-data/network/interfaces/macs/00:00:0A:AA:0A:0A/subnet-id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/html
+      Content-Length:
+      - '345'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Dec 2015 17:11:22 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="iso-8859-1"?>
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+         <head>
+          <title>404 - Not Found</title>
+         </head>
+         <body>
+          <h1>404 - Not Found</h1>
+         </body>
+        </html>
+    http_version:
+  recorded_at: Wed, 16 Dec 2015 17:11:22 GMT
+- request:
+    method: post
+    uri: https://ec2.ap-northeast-1.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DescribeInstances&InstanceId.1=i-0c0c0000&Version=2015-10-01
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.2.5 ruby/2.1.4 x86_64-linux
+      X-Amz-Date:
+      - 20151213T100607Z
+      Host:
+      - ec2.ap-northeast-1.amazonaws.com
+      Content-Length:
+      - '67'
+      Accept:
+      - '*/*'
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Sun, 13 Dec 2015 10:06:07 GMT
+      Server:
+      - AmazonEC2
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2015-10-01/">
+            <requestId>00f71347-3b87-4f5b-a60f-8c46d76ea808</requestId>
+            <reservationSet>
+                <item>
+                    <reservationId>r-44d8965d</reservationId>
+                    <ownerId>000000000000</ownerId>
+                    <groupSet/>
+                    <instancesSet>
+                        <item>
+                            <instanceId>i-0c0c0000</instanceId>
+                            <tagSet>
+                                <item>
+                                    <key>Name</key>
+                                    <value>instance-name</value>
+                                </item>
+                                <item>
+                                    <key>aws:cloudformation:stack-name</key>
+                                    <value>mystack</value>
+                                </item>
+                            </tagSet>
+                        </item>
+                    </instancesSet>
+                </item>
+            </reservationSet>
+        </DescribeInstancesResponse>
+    http_version:
+  recorded_at: Sun, 13 Dec 2015 10:06:07 GMT
+- request:
+    method: get
+    uri: http://169.254.169.254/latest/dynamic/instance-identity/document
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      X-aws-ec2-metadata-token:
+      - AAAAAAAAAAAAA__AAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAAAAAAAAA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"2871764318"'
+      Last-Modified:
+      - Wed, 11 May 2016 20:52:55 GMT
+      Content-Length:
+      - '422'
+      Connection:
+      - close
+      Date:
+      - Wed, 11 May 2016 21:05:40 GMT
+      Server:
+      - EC2ws
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "privateIp" : "172.31.1.232",
+          "devpayProductCodes" : null,
+          "availabilityZone" : "us-west-1c",
+          "version" : "2010-08-31",
+          "instanceId" : "i-123456",
+          "billingProducts" : null,
+          "instanceType" : "t2.micro",
+          "accountId" : "123456789",
+          "imageId" : "ami-123456",
+          "pendingTime" : "2016-05-11T20:52:25Z",
+          "architecture" : "x86_64",
+          "kernelId" : null,
+          "ramdiskId" : null,
+          "region" : "us-west-1"
+        }
+    http_version:
+  recorded_at: Wed, 11 May 2016 21:05:40 GMT
+recorded_with: VCR 3.0.1

--- a/test/plugin/test_filter_ec2_metadata.rb
+++ b/test/plugin/test_filter_ec2_metadata.rb
@@ -55,6 +55,36 @@ class EC2MetadataFilterTest < Test::Unit::TestCase
     end
   end
 
+  test 'configure-vpc-with-imdsv2' do
+    VCR.use_cassette('ec2-vpc-with-imdsv2', :allow_playback_repeats => true) do
+      c = %[
+        aws_key_id aws_key
+        aws_sec_key aws_sec
+        imdsv2 true
+        <record>
+          name ${tagset_name}
+        </record>
+      ]
+      d = create_driver(conf=c)
+
+      assert_equal("aws_key", d.instance.aws_key_id)
+      assert_equal("aws_sec", d.instance.aws_sec_key)
+
+      assert_equal("ami-123456", d.instance.ec2_metadata['image_id'])
+      assert_equal("123456789", d.instance.ec2_metadata['account_id'])
+
+      assert_equal("i-0c0c0000", d.instance.ec2_metadata['instance_id'])
+      assert_equal("m3.large", d.instance.ec2_metadata['instance_type'])
+      assert_equal("ap-northeast-1", d.instance.ec2_metadata['region'])
+      assert_equal("ap-northeast-1b", d.instance.ec2_metadata['availability_zone'])
+      assert_equal("00:A0:00:0A:AA:00", d.instance.ec2_metadata['mac'])
+      assert_equal("vpc-00000000", d.instance.ec2_metadata['vpc_id'])
+      assert_equal("subnet-00000000", d.instance.ec2_metadata['subnet_id'])
+
+      assert_equal("instance-name", d.instance.ec2_metadata['tagset_name'])
+    end
+  end
+
   test 'configure-classic' do
     VCR.use_cassette('ec2-classic') do
       c = %[


### PR DESCRIPTION
Use new Instance Metadata Service to get metadata.

https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/

This change will help to disable IMDSv1 in the public instance.
To keep compatible with ec2-classic environment, I add `imdsv2` option.