### PR TITLE
Changing the tagset detection

### DIFF
--- a/lib/fluent/plugin/ec2_metadata.rb
+++ b/lib/fluent/plugin/ec2_metadata.rb
@@ -96,7 +96,7 @@ module Fluent
     end
 
     def set_tag(ec2_metadata)
-      if @map.values.any? { |v| v.match(/^\${tagset_/) } || @output_tag =~ /\${tagset_/
+      if @map.values.any? { |v| v.match(/\${tagset_/) } || @output_tag =~ /\${tagset_/
 
         if @aws_key_id and @aws_sec_key
           ec2 = Aws::EC2::Client.new(


### PR DESCRIPTION
Changing the tagset detection (no required for the beginning of the phrase) so that the tag can be searched for in a not simple value